### PR TITLE
Fix: Correct typo in label from 'Pizza Type' to 'Pizza Size' in Order Component

### DIFF
--- a/lessons/04-core-react-concepts/B-hooks.md
+++ b/lessons/04-core-react-concepts/B-hooks.md
@@ -38,7 +38,7 @@ export default function Order() {
             </select>
           </div>
           <div>
-            <label htmlFor="pizza-size">Pizza Type</label>
+            <label htmlFor="pizza-size">Pizza Size</label>
             <div>
               <span>
                 <input


### PR DESCRIPTION
### Fix Typo in Order component

This pull request corrects a typo in the JSX of the Order component on the course website (Hooks section) and resolves [this issue](https://github.com/btholt/complete-intro-to-react-v9/issues/5).

I updated the label in the Order component to display `Pizza Size` instead of `Pizza Type` as intended.

#### Note
@btholt, thank you for putting together such a comprehensive and engaging React course! It’s been an incredible learning experience 😊🙏🏾!

