### PR TITLE
🩹 fix broken localhost links

### DIFF
--- a/lessons/02-no-frills-react/A-react-without-a-build-step.md
+++ b/lessons/02-no-frills-react/A-react-without-a-build-step.md
@@ -37,7 +37,7 @@ Let's start your project. Create your project directory inside the repo. I'm goi
 </html>
 ```
 
-Let's run this. We could open it directly in our browser but I like using [serve][serve]. Run `npx serve` and open [http://localhost:3000/]() in your browser.
+Let's run this. We could open it directly in our browser but I like using [serve][serve]. Run `npx serve` and open http://localhost:3000/ in your browser.
 
 - Pretty standard HTML5 document. If this is confusing, I teach another course called [Intro to Web Dev][webdev] that can help you out.
 - We're adding a root div. We'll render our React app here in a sec. It doesn't _have_ to be called root, just a common practice.

--- a/lessons/03-tools/E-vite.md
+++ b/lessons/03-tools/E-vite.md
@@ -88,7 +88,7 @@ Be sure to also add `"type: module"` to your package.json. Vite has deprecated s
 > Note: you will get a warning from Vite like `Files in the public directory are served at the root path.
 Instead of /public/style.css, use /style.css.` – ignore this, we'll fix it in a bit.
 
-`dev` will start the development server, typically on [http://localhost:5173/](). `build` will prepare static files to be deployed (to somewhere like GitHub Pages, Vercel, Netlify, AWS S3, etc.) `preview` lets you preview your production build locally.
+`dev` will start the development server, typically on http://localhost:5173/. `build` will prepare static files to be deployed (to somewhere like GitHub Pages, Vercel, Netlify, AWS S3, etc.) `preview` lets you preview your production build locally.
 
 > Note that we've changed domains here. By default Vite uses localhost:5173. Fun fact, 5173 sort of spells VITE if you make the 5 its Roman Numeral version, V.
 

--- a/lessons/04-core-react-concepts/A-jsx.md
+++ b/lessons/04-core-react-concepts/A-jsx.md
@@ -132,7 +132,7 @@ Notice we have Pizza as a component. Notice that the `P` in `Pizza` is capitaliz
 
 We now pass props down as we add attributes to an HTML tag. Pretty cool.
 
-You can test your app by running `npm run dev` and opening the URL shown in the terminal. It's typically [http://localhost:5173/]()
+You can test your app by running `npm run dev` and opening the URL shown in the terminal. It's typically http://localhost:5173/
 
 ## The API / Image Server
 

--- a/lessons/04-core-react-concepts/B-hooks.md
+++ b/lessons/04-core-react-concepts/B-hooks.md
@@ -100,7 +100,7 @@ import Order from "./Order";
 
 > 🚨 You'll have some errors in the console, that's okay.
 
-Now navigate to [http://localhost:5173/]() and see that you have two inputs, one for the pizza type and a set of radio buttons for the size. Try and select something with the inputs. You'll see that you can't modify them. Why? Let's think about how React works: when you interact with the inputs, React detects that a DOM event happens. When that happens, React thinks _something_ may have changed so it runs a re-render. Providing your render functions are fast, this is a very quick operation. It then diffs what's currently there and what its render pass came up with. It then updates the minimum amount of DOM necessary.
+Now navigate to http://localhost:5173/ and see that you have two inputs, one for the pizza type and a set of radio buttons for the size. Try and select something with the inputs. You'll see that you can't modify them. Why? Let's think about how React works: when you interact with the inputs, React detects that a DOM event happens. When that happens, React thinks _something_ may have changed so it runs a re-render. Providing your render functions are fast, this is a very quick operation. It then diffs what's currently there and what its render pass came up with. It then updates the minimum amount of DOM necessary.
 
 > In the recorded course, the layout is vertical because the `order-pizza` DIV was in the wrong place. Use the markup above. The layout should look like this:
 


### PR DESCRIPTION
Some of the localhost links only point to the current page ([example](https://react-v9.holt.courses/lessons/no-frills-react/react-without-a-build-step#:~:text=http%3A//localhost%3A3000/)).
These changes fix these links.

👋