### PR TITLE
Fix: Update Testing Documentation to Correctly Reference Vitest

### DIFF
--- a/lessons/07-testing/A-vitest.md
+++ b/lessons/07-testing/A-vitest.md
@@ -44,7 +44,7 @@ Let's go add an npm script. In your package.json.
 
 > Fun trick: if you call it test, npm lets you run that command as just `npm t`.
 
-This command lets you run Jest in an interactive mode where it will re-run tests selectively as you save them. This lets you get instant feedback if your test is working or not. This is probably my favorite feature of Vitest.
+This command lets you run Vitest in an interactive mode where it will re-run tests selectively as you save them. This lets you get instant feedback if your test is working or not. This is probably my favorite feature of Vitest.
 
 Okay, one little configuration to add to your `vite.config.js`.
 


### PR DESCRIPTION
## Changes
- Updated documentation in `lessons/07-testing/A-vitest.md` to correctly reference Vitest instead of Jest

## Description
This PR fixes a documentation inconsistency where the testing framework was incorrectly referred to as Jest instead of Vitest. The changes ensure that the documentation accurately reflects the use of Vitest as the testing framework. It solves #11 

