### PR TITLE
Fix formatting for package.json 'type' instruction in vite lesson md

### DIFF
--- a/lessons/03-tools/E-vite.md
+++ b/lessons/03-tools/E-vite.md
@@ -83,7 +83,7 @@ Now let's set up our scripts to start Vite. In package.json, put:
 "preview": "vite preview"
 ```
 
-Be sure to also add `"type: module"` to your package.json. Vite has deprecated support for Common.js and now requires you to use ESM style modules.
+Be sure to also add `"type": "module"` to your package.json. Vite has deprecated support for Common.js and now requires you to use ESM style modules.
 
 > Note: you will get a warning from Vite like `Files in the public directory are served at the root path.
 Instead of /public/style.css, use /style.css.` – ignore this, we'll fix it in a bit.


### PR DESCRIPTION
Corrected formatting for the 'type' field in package.json instructions in the Vite section.